### PR TITLE
Fix sorting header rendering if settings exist

### DIFF
--- a/web/extensions/sorting.js
+++ b/web/extensions/sorting.js
@@ -57,7 +57,8 @@ define(['../override', 'jquery', '../utils', '../datasources/sortingdatasource.j
                         if(column.sortable === undefined || column.sortable) {
                             header.append('<div class=\'pg-sorter\'>');
                             header.addClass('pg-sortable');
-                            if(sortColumns[0] && sortColumns[0].key === column.key) {
+                            var key = typeof column.key === 'string' ? column.key : JSON.stringify(column.key);
+                            if(sortColumns[0] && sortColumns[0].key === key) {
                                 header.addClass('pg-sort-' + sortColumns[0].direction);
                             }
                         }


### PR DESCRIPTION
column.key is a number which causes the equality check to fail. Rather than assuming that this would never work, I've added a check to see if it is a string before trying to convert it.